### PR TITLE
Add support for optional installation arguments (fixes Issue #6 and replaces PR #7)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,10 @@
 ---
 oneagent_installer_script_url:
+
+# variables passed to the installer script
+dynatrace_app_log_content_access: 1
+dynatrace_infra_only: 0
+
 # for backward compatibility:
 dynatrace_oneagent_cluster_subdomain:
 dynatrace_oneagent_environment_id:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,6 @@ oneagent_installer_script_url:
 
 # variables passed to the installer script
 dynatrace_app_log_content_access: 1
-dynatrace_infra_only: 0
 
 # for backward compatibility:
 dynatrace_oneagent_cluster_subdomain:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,6 @@
    when: agent_installed.stat.exists == False and (oneagent_installer_script_url is defined) and (oneagent_installer_script_url is not none)
 
  - name: "Install Dynatrace OneAgent"
-   shell: "sh /tmp/dynatrace-oneagent.sh"
+   shell: "sh /tmp/dynatrace-oneagent.sh APP_LOG_CONTENT_ACCESS={{ dynatrace_app_log_content_access }} INFRA_ONLY={{ dynatrace_infra_only }}"
    become: yes
    when: ansible_architecture != "armv7l" and agent_installed.stat.exists == False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,6 @@
    when: agent_installed.stat.exists == False and (oneagent_installer_script_url is defined) and (oneagent_installer_script_url is not none)
 
  - name: "Install Dynatrace OneAgent"
-   shell: "sh /tmp/dynatrace-oneagent.sh APP_LOG_CONTENT_ACCESS={{ dynatrace_app_log_content_access }} INFRA_ONLY={{ dynatrace_infra_only }}"
+   shell: "sh /tmp/dynatrace-oneagent.sh APP_LOG_CONTENT_ACCESS={{ dynatrace_app_log_content_access }}{% if dynatrace_infra_only is defined %} INFRA_ONLY={{ dynatrace_infra_only }}{% endif %}"
    become: yes
    when: ansible_architecture != "armv7l" and agent_installed.stat.exists == False


### PR DESCRIPTION
Add support for setting `APP_LOG_CONTENT_ACCESS` and, optionally, `INFRA_ONLY` in the command line installation arguments.

This builds off of @dannywillford PR #7 but makes the `dynatrace_infra_only` an optional Ansible variable: if `dynatrace_infra_only` is not set, then `INFRA_ONLY` won't be in the the command line arguments for Dynatrace installation. (This resolves @MarcinZejer comment https://github.com/Dynatrace/Dynatrace-OneAgent-Ansible/pull/7#issuecomment-410716773 ).

