### PR TITLE
Host Group Support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,15 @@ oneagent_installer_script_url:
 
 # variables passed to the installer script
 dynatrace_app_log_content_access: 1
+# Optional (recommended) parameter.
+# See: https://www.dynatrace.com/support/help/how-to-use-dynatrace/hosts/configuration/organize-your-environment-using-host-groups/
+# Host Groups must be shorter than 100 characters and can contain:
+# - alphanumeric characters
+# - hyphen (-)
+# - underscore (_)
+# - dot (.)
+# Host Groups must NOT start with 'dt.'
+dynatrace_oneagent_host_group: host-group
 
 # for backward compatibility:
 dynatrace_oneagent_cluster_subdomain:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,6 @@
    when: agent_installed.stat.exists == False and (oneagent_installer_script_url is defined) and (oneagent_installer_script_url is not none)
 
  - name: "Install Dynatrace OneAgent"
-   shell: "sh /tmp/dynatrace-oneagent.sh APP_LOG_CONTENT_ACCESS={{ dynatrace_app_log_content_access }}{% if dynatrace_infra_only is defined %} INFRA_ONLY={{ dynatrace_infra_only }}{% endif %}"
+   shell: "sh /tmp/dynatrace-oneagent.sh APP_LOG_CONTENT_ACCESS={{ dynatrace_app_log_content_access }}{% if dynatrace_infra_only is defined %} INFRA_ONLY={{ dynatrace_infra_only }}{% endif %}{% if dynatrace_oneagent_host_group is defined %} --set-host-group={{ dynatrace_oneagent_host_group }}{% endif %}"
    become: yes
    when: ansible_architecture != "armv7l" and agent_installed.stat.exists == False


### PR DESCRIPTION
Add support for specifying host group at install time.

This pull request:
- Introduces 1 new (optional) parameter: `dynatrace_oneagent_host_group` specified in `defaults/main.yml`.
- Utilises this variable (if set) at install time with `--set-host-group=X`