### PR TITLE
Trigger "restart oneagent" after configuration change

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -4,12 +4,14 @@
       dest: "{{ dynatrace_oneagent_hostautotag_config_file }}"
       content: "{{ dynatrace_oneagent_host_tags }}"
     when: ansible_system|lower == "linux"
+    notify: restart oneagent linux
 
   - name: create/update hostcustomproperties.conf file | Linux
     copy:
       dest: "{{ dynatrace_oneagent_hostmetadata_config_file }}"
       content: "{{ dynatrace_oneagent_host_metadata }}"
     when: dynatrace_oneagent_host_metadata and ansible_system|lower == "linux"
+    notify: restart oneagent linux
 
   - name: create/update hostname.conf file | linux
     copy:
@@ -23,12 +25,14 @@
       dest: "{{ dynatrace_oneagent_hostautotag_config_file }}"
       content: "{{ dynatrace_oneagent_host_tags }}"
     when: ansible_system|lower == "win32nt"
+    notify: restart oneagent windows
 
   - name: create/update hostcustomproperties.conf file | windows
     win_copy:
       dest: "{{ dynatrace_oneagent_hostmetadata_config_file }}"
       content: "{{ dynatrace_oneagent_host_metadata }}"
     when: dynatrace_oneagent_host_metadata and ansible_system|lower == "win32nt"
+    notify: restart oneagent windows
 
   - name: create/update hostname.conf file | windows
     win_copy:


### PR DESCRIPTION
Every configuration change should restart the agent to apply the changes.