### PR TITLE
Create release mechanism for the collection

### DIFF
--- a/.github/actions/publish-to-ansible-galaxy/action.yaml
+++ b/.github/actions/publish-to-ansible-galaxy/action.yaml
@@ -1,0 +1,28 @@
+# Copyright 2024 Dynatrace LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: publish-to-ansible-galaxy
+description: Publish to Ansible Galaxy
+
+inputs:
+  ansible-galaxy-api-token:
+    description: Ansible Galaxy API token required for ansible-galaxy client authentication
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Publish the Ansible collection
+      shell: bash
+      run: ansible-galaxy collection publish dynatrace-oneagent* --token ${{ inputs.ansible-galaxy-api-token }}

--- a/.github/actions/set-environment-variables/action.yaml
+++ b/.github/actions/set-environment-variables/action.yaml
@@ -1,0 +1,23 @@
+# Copyright 2024 Dynatrace LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Set environment variables
+description: Set environment variables required for other actions
+
+runs:
+  using: composite
+  steps:
+    - name: Set environment variables
+      shell: bash
+      run: printf "FILES_DIR=roles/oneagent/files\n" >> $GITHUB_ENV

--- a/.github/actions/update-version/action.yaml
+++ b/.github/actions/update-version/action.yaml
@@ -1,0 +1,49 @@
+# Copyright 2024 Dynatrace LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: update-version
+description: Update version
+
+runs:
+  using: composite
+  steps:
+    - name: Get latest tag
+      shell: bash
+      run: printf "LATEST_TAG=%s\n" "$(git describe --tags --abbrev=0 --always)" >> $GITHUB_ENV
+
+    - name: Extract version
+      shell: bash
+      run: |
+        latestTag="${{ env.LATEST_TAG }}"
+        printf "LATEST_VERSION=%s\n" "${latestTag#v}" >> $GITHUB_ENV
+
+    - name: Update galaxy.yml version
+      shell: bash
+      run: |
+        latestVersion="${{ env.LATEST_VERSION }}"
+        sed -i "s/version: .*/version: ${latestVersion}/" galaxy.yml
+    
+    - name: Configure git
+      shell: bash
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+    
+    - name: Commit and push changes
+      shell: bash
+      run: |
+        git checkout master
+        git add galaxy.yml
+        git commit -m "Update galaxy.yaml version to ${{ env.LATEST_VERSION }}"
+        git push origin master

--- a/.github/workflows/build-test-and-publish.yaml
+++ b/.github/workflows/build-test-and-publish.yaml
@@ -12,28 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Build and test
+name: Build, test and publish
 on:
-  pull_request:
-    branches: [ "*" ]
   push:
-    branches: [ "*" ]
-  workflow_dispatch:
-  workflow_call:
-
-env:
-  FILES_DIR: roles/oneagent/files
+    tags:
+      - "v*.*.*" 
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set environment variables
         uses: ./.github/actions/set-environment-variables
+      - name: Update version
+        uses: ./.github/actions/update-version
       - name: Set up environment
         uses: ./.github/actions/setup-build-environment
       - name: Build the collection
         uses: ./.github/actions/build-collection
       - name: Run tests
         uses: ./.github/actions/run-tests
+      - name: Publish to Ansible Galaxy
+        uses: ./.github/actions/publish-to-ansible-galaxy
+        with:
+          ansible-galaxy-api-token: ${{ secrets.ANSIBLE_GALAXY_API_TOKEN }}

--- a/.github/workflows/build-test-and-upload.yaml
+++ b/.github/workflows/build-test-and-upload.yaml
@@ -15,14 +15,19 @@
 name: Build, test and upload
 on:
   push:
-    branches: [ 'main' ]
+    branches: [ "master" ]
   workflow_dispatch:
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Build and test
-        uses: ./.github/workflows/build-and-test.yaml
-      - name: Upload the collection
-        uses: ./.github/actions/upload-collection
+      - uses: actions/checkout@v4
+      - name: Set environment variables
+        uses: ./.github/actions/set-environment-variables
+      - name: Set up environment
+        uses: ./.github/actions/setup-build-environment
+      - name: Build the collection
+        uses: ./.github/actions/build-collection
+      - name: Run tests
+        uses: ./.github/actions/run-tests

--- a/.github/workflows/build-test-and-upload.yaml
+++ b/.github/workflows/build-test-and-upload.yaml
@@ -31,3 +31,5 @@ jobs:
         uses: ./.github/actions/build-collection
       - name: Run tests
         uses: ./.github/actions/run-tests
+      - name: Upload the collection
+        uses: ./.github/actions/upload-collection


### PR DESCRIPTION
# Changes
## New Workflow – `Build, test and publish`
* runs when a new release in a `vX.Y.Z` format is created e.g.
![proof](https://github.com/Dynatrace/Dynatrace-OneAgent-Ansible/assets/68189467/fc420676-b3d7-4820-8ae6-5c33f7c36939)
* automatically updates `galaxy.yml` version to the version of the created release i.e. `X.Y.Z` and commits the change to `master` branch
* builds the collection and tests it
* publishes the built collection to Ansible Galaxy through API Token authentication
  * Ansible Galaxy API Token can be accesses from GitHub repository secrets
## Improvements
* removed `Build, test and upload` workflow dependency on `Build and test` workflow
  * reusing `Build and test` could only be done for `Build, test and upload` and not `Build, test and publish`, which proved confusing
## Fixes
* changed branch in `Build, test and upload` workflow from `main` to `master`