### PR TITLE
Add download of CA certificate

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" default="true">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/roles/oneagent/tasks/provide-installer/signature-unix.yml
+++ b/roles/oneagent/tasks/provide-installer/signature-unix.yml
@@ -1,9 +1,23 @@
 ---
+- name: Check if CA certificate exists
+  delegate_to: localhost
+  ansible.builtin.stat:
+    path: "{{ oneagent_ca_cert_src_path }}"
+  register: _oneagent_ca_cert_state
+
 - name: Transfer CA certificate
   ansible.builtin.copy:
     src: "{{ oneagent_ca_cert_src_path }}"
     dest: "{{ oneagent_ca_cert_dest_path }}"
     mode: "0644"
+  when: _oneagent_ca_cert_state.stat.exists
+
+- name: Download CA certificate
+  ansible.builtin.get_url:
+    url: "{{ oneagent_ca_cert_download_url }}"
+    dest: "{{ oneagent_ca_cert_dest_path }}"
+    mode: "0644"
+  when: not _oneagent_ca_cert_state.stat.exists
 
 - name: Validate installer signature
   ansible.builtin.shell: >

--- a/roles/oneagent/vars/aix.yml
+++ b/roles/oneagent/vars/aix.yml
@@ -17,6 +17,7 @@ oneagent_uninstall_cmd: sh {{ oneagent_install_path }}/agent/uninstall.sh
 
 oneagent_ca_cert_src_path: files/dt-root.cert.pem
 oneagent_ca_cert_dest_path: "{{ oneagent_download_path }}/dt-root.cert.pem"
+oneagent_ca_cert_download_url: https://ca.dynatrace.com/dt-root.cert.pem
 oneagent_certificate_verification_header: >
   "Content-Type: multipart/signed; protocol=\"application/x-pkcs7-signature\"; micalg=\"sha-256\"; boundary=\"--SIGNED-INSTALLER\"\
   \n\n----SIGNED-INSTALLER\n"

--- a/roles/oneagent/vars/linux.yml
+++ b/roles/oneagent/vars/linux.yml
@@ -18,6 +18,7 @@ oneagent_uninstall_cmd: sh {{ oneagent_install_path }}/agent/uninstall.sh
 
 oneagent_ca_cert_src_path: files/dt-root.cert.pem
 oneagent_ca_cert_dest_path: "{{ oneagent_download_path }}/dt-root.cert.pem"
+oneagent_ca_cert_download_url: https://ca.dynatrace.com/dt-root.cert.pem
 oneagent_certificate_verification_header: >
   "Content-Type: multipart/signed; protocol=\"application/x-pkcs7-signature\"; micalg=\"sha-256\"; boundary=\"--SIGNED-INSTALLER\"\
   \n\n----SIGNED-INSTALLER\n"


### PR DESCRIPTION
Add option for downloading certificate instead of using embedded one. 
This fixes the problem with cloned repositories as the certificate was added during collection build process.
Tested only manually. Once the https://github.com/Dynatrace/Dynatrace-OneAgent-Ansible/pull/41 is merged, automatic tests will be added.