### PR TITLE
Add option to run tests on Windows

### DIFF
--- a/roles/oneagent/tasks/provide-installer/signature-unix.yml
+++ b/roles/oneagent/tasks/provide-installer/signature-unix.yml
@@ -10,7 +10,7 @@
     src: "{{ oneagent_ca_cert_src_path }}"
     dest: "{{ oneagent_ca_cert_dest_path }}"
     mode: "0644"
-  when: _oneagent_ca_cert_state.stat.exists
+  when: not (oneagent_force_cert_download | default(true)) and _oneagent_ca_cert_state.stat.exists
 
 - name: Download CA certificate
   ansible.builtin.get_url:
@@ -20,7 +20,7 @@
     validate_certs: "{{ oneagent_validate_certs | default(true) }}"
   environment:
     SSL_CERT_FILE: "{{ oneagent_ca_cert_download_cert | default(omit) }}"
-  when: not _oneagent_ca_cert_state.stat.exists
+  when: oneagent_force_cert_download | default(true) or not _oneagent_ca_cert_state.stat.exists
 
 - name: Validate installer signature
   ansible.builtin.shell: >

--- a/roles/oneagent/tests/README.md
+++ b/roles/oneagent/tests/README.md
@@ -27,6 +27,10 @@ $ mkdir -p roles/oneagent/files && wget https://ca.dynatrace.com/dt-root.cert.pe
 $ ansible-galaxy collection build . -vvv
 $ sudo bash -c "source venv/bin/activate && ansible-galaxy collection install -vvv dynatrace-oneagent*"
 
-# Run tests (eg. For linux_x86 platform)
+# Run tests (eg. For linux_x86 platform on local machine)
 $ sudo bash -c "source venv/bin/activate && pytest roles/oneagent/tests --linux_x86=localhost"
+
+# Run tests with regular installer on remote machine
+$ sudo bash -c "source venv/bin/activate && pytest roles/oneagent/tests --user=<USER> --password=<password> \
+  --windows_x86=<IP> --tenant=https://abc123456.com --tenant_token=<TOKEN>"
 ```

--- a/roles/oneagent/tests/README.md
+++ b/roles/oneagent/tests/README.md
@@ -1,7 +1,12 @@
 # Component tests
-The tests are using mocked version of the OneAgent installer, which simulates its basic behavior - returning version, 
-deploying `uninstall.sh` script and creating `oneagentctl`, used for configuring installation. The tests can run on 
-the same machine as main node.
+The tests support two types of deployment:
+- local  - the tests are run on the same Unix machine as main node;
+- remote - the tests are run on a remote Windows machine;
+Currently, there is no option to mix these two types of deployment and the tests must be run for one platform at a time.
+For local deployment, the tests are using mocked version of the OneAgent installer, which simulates its basic behavior -
+returning version, deploying `uninstall.sh` script and creating `oneagentctl`, used for configuring installation.
+For remote deployment, regular OneAgent installers are used, which are downloaded from the Dynatrace environment during
+the tests.
 
 ## Requirements
 - Python 3.10+
@@ -27,10 +32,10 @@ $ mkdir -p roles/oneagent/files && wget https://ca.dynatrace.com/dt-root.cert.pe
 $ ansible-galaxy collection build . -vvv
 $ sudo bash -c "source venv/bin/activate && ansible-galaxy collection install -vvv dynatrace-oneagent*"
 
-# Run tests (eg. For linux_x86 platform on local machine)
+# Run tests for linux_x86 platform on local machine
 $ sudo bash -c "source venv/bin/activate && pytest roles/oneagent/tests --linux_x86=localhost"
 
-# Run tests with regular installer on remote machine
+# Run tests with regular installer on remote Windows machine
 $ sudo bash -c "source venv/bin/activate && pytest roles/oneagent/tests --user=<USER> --password=<password> \
-  --windows_x86=<IP> --tenant=https://abc123456.com --tenant_token=<TOKEN>"
+--tenant=https://abc123456.com --tenant_token=<TOKEN> --windows_x86=<IP>"
 ```

--- a/roles/oneagent/tests/README.md
+++ b/roles/oneagent/tests/README.md
@@ -1,12 +1,24 @@
 # Component tests
 The tests support two types of deployment:
 - local  - the tests are run on the same Unix machine as main node;
-- remote - the tests are run on a remote Windows machine;
+- remote - the tests are run on a remote Windows (Unix is not supported at the moment) machine;
 Currently, there is no option to mix these two types of deployment and the tests must be run for one platform at a time.
+
+## Remote deployment
+For remote deployment, regular OneAgent installers are used, which are downloaded from the Dynatrace environment during
+the tests. To use this type of deployment, the following parameters must be provided:
+- `--user` - username for the remote machine;
+- `--password` - password for the remote machine;
+- `--tenant` - The environment URL from which the installer will be downloaded, in form of `https://abc123456.com`;
+- `--tenant_token` - Token for downloading the installer, generated in Deployment UI;
+- `--windows_x86=<IP>` - IP address of the remote Windows machine;
+Failing to provide any of these parameters will result in failure.
+
+## Local deployment
 For local deployment, the tests are using mocked version of the OneAgent installer, which simulates its basic behavior -
 returning version, deploying `uninstall.sh` script and creating `oneagentctl`, used for configuring installation.
-For remote deployment, regular OneAgent installers are used, which are downloaded from the Dynatrace environment during
-the tests.
+To use this type of deployment, the only required parameter is `--linux_x86=localhost`. In case, multiple platforms for
+local deployment are specified or any other platforms is used along with local one, only the first local platform is used.
 
 ## Requirements
 - Python 3.10+
@@ -32,7 +44,7 @@ $ mkdir -p roles/oneagent/files && wget https://ca.dynatrace.com/dt-root.cert.pe
 $ ansible-galaxy collection build . -vvv
 $ sudo bash -c "source venv/bin/activate && ansible-galaxy collection install -vvv dynatrace-oneagent*"
 
-# Run tests for linux_x86 platform on local machine
+# Run tests for any platform (except from Windows) on local machine
 $ sudo bash -c "source venv/bin/activate && pytest roles/oneagent/tests --linux_x86=localhost"
 
 # Run tests with regular installer on remote Windows machine

--- a/roles/oneagent/tests/ansible/config.py
+++ b/roles/oneagent/tests/ansible/config.py
@@ -28,6 +28,7 @@ def _prepare_collection() -> None:
     shutil.rmtree(TEST_COLLECTIONS_DIR, ignore_errors=True)
     shutil.copytree(INSTALLED_COLLECTIONS_DIR, TEST_COLLECTIONS_DIR)
 
+
 def _prepare_playbook_file() -> None:
     shutil.copy(
         str(ANSIBLE_RESOURCE_DIR / PLAYBOOK_TEMPLATE_FILE_NAME), str(TEST_DIRECTORY / PLAYBOOK_TEMPLATE_FILE_NAME)
@@ -71,11 +72,13 @@ class AnsibleConfig:
     VERIFY_SIGNATURE_KEY = "oneagent_verify_signature"
     INSTALLER_VERSION_KEY = "oneagent_version"
     PRESERVE_INSTALLER_KEY = "oneagent_preserve_installer"
-    CA_CERT_DOWNLOAD_URL_KEY = "oneagent_ca_cert_download_url"
-    CA_CERT_DOWNLOAD_CERT_KEY = "oneagent_ca_cert_download_cert"
+
     # Internal parameters
+    FORCE_CERT_DOWNLOAD_KEY = "oneagent_force_cert_download"
+    CA_CERT_DOWNLOAD_CERT_KEY = "oneagent_ca_cert_download_cert"
     VALIDATE_DOWNLOAD_CERTS_KEY = "oneagent_validate_certs"
     INSTALLER_DOWNLOAD_CERT_KEY = "oneagent_installer_download_cert"
+    CA_CERT_DOWNLOAD_URL_KEY = "oneagent_ca_cert_download_url"
 
     # Platform-specific
     DOWNLOAD_DIR_KEY = "oneagent_download_dir"

--- a/roles/oneagent/tests/conftest.py
+++ b/roles/oneagent/tests/conftest.py
@@ -79,14 +79,14 @@ def prepare_installers(request) -> None:
 
     if is_local_deployment(platforms):
         logging.info("Generating installers...")
-        generate_installers()
+        if not generate_installers():
+            pytest.exit("Generating installers failed")
     elif tenant and tenant_token:
-        logging.info("Downloading installers...")
-        assert download_signature()
-        assert download_installers(tenant, tenant_token, platforms)
+        logging.info("Downloading installers and signature...")
+        if not download_signature() or not download_installers(tenant, tenant_token, platforms):
+            pytest.exit("Downloading installers and signature failed")
     else:
-        logging.error("No tenant or tenant token provided, cannot download installers")
-        sys.exit(-1)
+        pytest.exit("No tenant or tenant token provided, cannot download installers")
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/roles/oneagent/tests/pytest.ini
+++ b/roles/oneagent/tests/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 pythonpath = .
+dynatrace_ca_cert_url = "https://ca.dynatrace.com/dt-root.cert.pem"

--- a/roles/oneagent/tests/test_installAndConfig.py
+++ b/roles/oneagent/tests/test_installAndConfig.py
@@ -114,6 +114,3 @@ def test_basic_installation(runner, configurator, platforms, wrapper, installer_
 
     logging.info("Check if installer args were passed correctly")
     perform_operation_on_platforms(platforms, _check_install_args, wrapper, TECH_NAME)
-
-
-

--- a/roles/oneagent/tests/test_resilience.py
+++ b/roles/oneagent/tests/test_resilience.py
@@ -156,6 +156,7 @@ def test_failed_signature_verification(_error_messages, runner, configurator, pl
     logging.info("Running failed signature verification test")
 
     set_installer_download_params(configurator, installer_server_url)
+    configurator.set_common_parameter(configurator.FORCE_CERT_DOWNLOAD_KEY, False)
     configurator.set_common_parameter(configurator.INSTALLER_VERSION_KEY, "latest")
 
     with TEST_SIGNATURE_FILE.open("w") as signature:

--- a/roles/oneagent/tests/test_resilience.py
+++ b/roles/oneagent/tests/test_resilience.py
@@ -7,7 +7,6 @@ from ansible.constants import TEST_SIGNATURE_FILE, ERROR_MESSAGES_FILE, FAILED_D
 from util.common_utils import read_yaml_file
 from util.test_data_types import DeploymentResult
 from util.test_helpers import run_deployment, set_installer_download_params, enable_for_system_family
-from util.constants.common_constants import InstallerVersion
 
 MISSING_REQUIRED_PARAMETERS_KEY = "missing_mandatory_params"
 UNKNOWN_ARCHITECTURE_KEY = "unknown_arch"
@@ -157,7 +156,7 @@ def test_failed_signature_verification(_error_messages, runner, configurator, pl
     logging.info("Running failed signature verification test")
 
     set_installer_download_params(configurator, installer_server_url)
-    configurator.set_common_parameter(configurator.INSTALLER_VERSION_KEY, InstallerVersion.MALFORMED.value)
+    configurator.set_common_parameter(configurator.INSTALLER_VERSION_KEY, "latest")
 
     with TEST_SIGNATURE_FILE.open("w") as signature:
         signature.write("break signature by writing some text")

--- a/roles/oneagent/tests/util/constants/common_constants.py
+++ b/roles/oneagent/tests/util/constants/common_constants.py
@@ -20,8 +20,6 @@ INSTALLER_SYSTEM_NAME_TYPE_MAP = {"linux": "linux", "unix": "linux", "aix": "aix
 
 INSTALLER_SERVER_TOKEN = "abcdefghijk1234567890"
 
-
 class InstallerVersion(Enum):
     OLD = "1.199.0.20241008-150308"
-    MALFORMED = "1.259.0.20241008-150308"
     LATEST = "1.300.0.20241008-150308"

--- a/roles/oneagent/tests/util/installer_provider.py
+++ b/roles/oneagent/tests/util/installer_provider.py
@@ -1,6 +1,5 @@
 import logging
 import subprocess
-import sys
 
 import requests
 

--- a/roles/oneagent/tests/util/installer_provider.py
+++ b/roles/oneagent/tests/util/installer_provider.py
@@ -103,8 +103,7 @@ def download_and_save(path: Path, url: str, headers: dict[str, str]) -> bool:
     return True
 
 
-def download_signature() -> bool:
-    url = "https://ca.dynatrace.com/dt-root.cert.pem"
+def download_signature(url: str) -> bool:
     path = INSTALLERS_DIRECTORY / INSTALLER_CERTIFICATE_FILE_NAME
     return download_and_save(path, url, {})
 

--- a/roles/oneagent/tests/util/installer_provider.py
+++ b/roles/oneagent/tests/util/installer_provider.py
@@ -1,0 +1,129 @@
+import logging
+import subprocess
+import sys
+
+import requests
+
+from pathlib import Path
+
+from util.test_data_types import DeploymentPlatform, PlatformCollection
+from util.ssl_certificate_generator import SSLCertificateGenerator
+from util.constants.common_constants import (INSTALLERS_RESOURCE_DIR, INSTALLERS_DIRECTORY,
+                                             INSTALLER_PRIVATE_KEY_FILE_NAME, INSTALLER_CERTIFICATE_FILE_NAME,
+                                             InstallerVersion)
+
+
+def get_file_content(path: Path) -> list[str]:
+    with path.open("r") as f:
+        return f.readlines()
+
+
+def replace_tag(source: list[str], old: str, new: str) -> list[str]:
+    return [line.replace(old, new) for line in source]
+
+
+def sign_installer(installer: list[str]) -> list[str]:
+    cmd = ["openssl", "cms", "-sign",
+           "-signer", f"{INSTALLERS_DIRECTORY / INSTALLER_CERTIFICATE_FILE_NAME}",
+           "-inkey", f"{INSTALLERS_DIRECTORY / INSTALLER_PRIVATE_KEY_FILE_NAME}"]
+
+    proc = subprocess.run(cmd, input=f"{''.join(installer)}", encoding="utf-8", stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if proc.returncode != 0:
+        logging.error(f"Failed to sign installer: {proc.stdout}")
+        sys.exit(1)
+
+    signed_installer = proc.stdout.splitlines()
+    delimiter = next(l for l in signed_installer if l.startswith("----"))
+    index = signed_installer.index(delimiter)
+    signed_installer = signed_installer[index + 1:]
+
+    custom_delimiter = "----SIGNED-INSTALLER"
+    return [f"{l}\n" if not l.startswith(delimiter) else f"{l.replace(delimiter, custom_delimiter)}\n" for l in signed_installer]
+
+
+def generate_installers() -> None:
+    uninstall_template = get_file_content(INSTALLERS_RESOURCE_DIR / "uninstall.sh")
+    uninstall_code = replace_tag(uninstall_template, "$", r"\$")
+
+    oneagentctl_template = get_file_content(INSTALLERS_RESOURCE_DIR / "oneagentctl.sh")
+    oneagentctl_code = replace_tag(oneagentctl_template, "$", r"\$")
+
+    installer_partial_name = "Dynatrace-OneAgent-Linux"
+    installer_template = get_file_content(INSTALLERS_RESOURCE_DIR / f"{installer_partial_name}.sh")
+    installer_template = replace_tag(installer_template, "##UNINSTALL_CODE##", "".join(uninstall_code))
+    installer_template = replace_tag(installer_template, "##ONEAGENTCTL_CODE##", "".join(oneagentctl_code))
+
+    generator = SSLCertificateGenerator(
+        country_name="US",
+        state_name="California",
+        locality_name="San Francisco",
+        organization_name="Dynatrace",
+        common_name="127.0.0.1"
+    )
+    generator.generate_and_save(f"{INSTALLERS_DIRECTORY / INSTALLER_PRIVATE_KEY_FILE_NAME}",
+                                f"{INSTALLERS_DIRECTORY / INSTALLER_CERTIFICATE_FILE_NAME}")
+
+    # REMOVE INSTALLER VERSION
+    for version in InstallerVersion:
+        installer_code = replace_tag(installer_template, "##VERSION##", version.value)
+        installer_code = sign_installer(installer_code)
+        installer = INSTALLERS_DIRECTORY / f"{installer_partial_name}-{version.value}.sh"
+        with installer.open("w") as f:
+            f.writelines(installer_code)
+
+
+def get_installers_versions_from_tenant(tenant: str, tenant_token: str, system_family: str) -> list[str]:
+    url = f"{tenant}/api/v1/deployment/installer/agent/versions/{system_family}/default"
+    headers = {"accept": "application/json", "Authorization":  f"Api-Token {tenant_token}"}
+
+    resp = requests.get(url, headers=headers)
+
+    try:
+        versions = resp.json()["availableVersions"]
+        if len(versions) < 2:
+            logging.error(f"List of available installers is too short: {versions}")
+        else:
+            return [versions[0], versions[-1]]
+    except KeyError:
+        logging.error(f"Failed to get installer versions: {resp.content}")
+    return []
+
+
+def download_and_save(path: Path, url: str, headers: dict[str, str] = {}) -> bool:
+    resp = requests.get(url, headers=headers)
+
+    if not resp.ok:
+        logging.error("Failed to download file: %s", resp.text)
+        return False
+
+    with path.open("wb") as f:
+        f.write(resp.content)
+    return True
+
+
+def download_signature() -> bool:
+    url = "https://ca.dynatrace.com/dt-root.cert.pem"
+    path = INSTALLERS_DIRECTORY / INSTALLER_CERTIFICATE_FILE_NAME
+    return download_and_save(path, url)
+
+
+def download_installer(tenant, tenant_token, version: str, platform: DeploymentPlatform) -> bool:
+    family = platform.family()
+    url = f"{tenant}/api/v1/deployment/installer/agent/{family}/default/version/{version}"
+    headers = {"accept": "application/octet-stream", "Authorization":  f"Api-Token {tenant_token}"}
+
+    ext = "exe" if family == "windows" else "sh"
+    path = INSTALLERS_DIRECTORY / f"Dynatrace-OneAgent-{family}_{platform.arch()}-{version}.{ext}"
+
+    return download_and_save(path, url, headers)
+
+
+def download_installers(tenant, tenant_token, platforms: PlatformCollection) -> bool:
+    for platform, _ in platforms.items():
+        versions = get_installers_versions_from_tenant(tenant, tenant_token, platform.family())
+        if not versions:
+            return False
+        for version in versions:
+            if not download_installer(tenant, tenant_token, version, platform):
+                return False
+    return True

--- a/roles/oneagent/tests/util/test_helpers.py
+++ b/roles/oneagent/tests/util/test_helpers.py
@@ -46,6 +46,8 @@ def perform_operation_on_platforms(platforms: PlatformCollection, operation: Cal
 def set_ca_cert_download_params(config: AnsibleConfig, installer_server_url: str) -> None:
     config.set_common_parameter(config.CA_CERT_DOWNLOAD_URL_KEY, f"{installer_server_url}/{INSTALLER_CERTIFICATE_FILE_NAME}")
     config.set_common_parameter(config.CA_CERT_DOWNLOAD_CERT_KEY, f"{SERVER_DIRECTORY / SERVER_CERTIFICATE_FILE_NAME}")
+    config.set_common_parameter(config.FORCE_CERT_DOWNLOAD_KEY, True)
+
 
 def set_installer_download_params(config: AnsibleConfig, installer_server_url: str) -> None:
     config.set_common_parameter(config.ENVIRONMENT_URL_KEY, installer_server_url)

--- a/roles/oneagent/vars/aix.yml
+++ b/roles/oneagent/vars/aix.yml
@@ -17,7 +17,7 @@ oneagent_ctl_bin_path: "{{ oneagent_install_path }}/agent/tools/oneagentctl"
 oneagent_install_cmd: sh {{ oneagent_installer_path }}
 oneagent_uninstall_cmd: sh {{ oneagent_install_path }}/agent/uninstall.sh
 
-oneagent_ca_cert_src_path: files/dt-root.cert.pem
+oneagent_ca_cert_src_path: "{{ role_path }}/files/dt-root.cert.pem"
 oneagent_ca_cert_dest_path: "{{ oneagent_download_path }}/dt-root.cert.pem"
 oneagent_ca_cert_download_url: https://ca.dynatrace.com/dt-root.cert.pem
 oneagent_certificate_verification_header: >

--- a/roles/oneagent/vars/aix.yml
+++ b/roles/oneagent/vars/aix.yml
@@ -19,7 +19,6 @@ oneagent_uninstall_cmd: sh {{ oneagent_install_path }}/agent/uninstall.sh
 
 oneagent_ca_cert_src_path: "{{ role_path }}/files/dt-root.cert.pem"
 oneagent_ca_cert_dest_path: "{{ oneagent_download_path }}/dt-root.cert.pem"
-oneagent_ca_cert_download_url: https://ca.dynatrace.com/dt-root.cert.pem
 oneagent_certificate_verification_header: >
   Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="--SIGNED-INSTALLER"
 oneagent_service_name: oneagent

--- a/roles/oneagent/vars/linux.yml
+++ b/roles/oneagent/vars/linux.yml
@@ -18,7 +18,7 @@ oneagent_ctl_bin_path: "{{ oneagent_install_path }}/agent/tools/oneagentctl"
 oneagent_install_cmd: sh {{ oneagent_installer_path }}
 oneagent_uninstall_cmd: sh {{ oneagent_install_path }}/agent/uninstall.sh
 
-oneagent_ca_cert_src_path: files/dt-root.cert.pem
+oneagent_ca_cert_src_path: "{{ role_path }}/files/dt-root.cert.pem"
 oneagent_ca_cert_dest_path: "{{ oneagent_download_path }}/dt-root.cert.pem"
 oneagent_certificate_verification_header: >
   Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="--SIGNED-INSTALLER"


### PR DESCRIPTION
The localhost option for running tests won't work on Windows platform. In order to mitigate that, the tests can now download proper installers directly from tenant and use it in deployment. The required tenant token can be acquired directly from deployment UI.
