### PR TITLE
Fix failure with running playbook with --check mode

### DIFF
--- a/roles/oneagent/tasks/provide-installer/signature-unix.yml
+++ b/roles/oneagent/tasks/provide-installer/signature-unix.yml
@@ -21,6 +21,7 @@
   environment:
     SSL_CERT_FILE: "{{ oneagent_ca_cert_download_cert | default(omit) }}"
   when: oneagent_force_cert_download | default(true) or not _oneagent_ca_cert_state.stat.exists
+  changed_when: false
 
 - name: Validate installer signature
   ansible.builtin.shell: >


### PR DESCRIPTION
Running the playbook in check mode fails on `Validate installer signature` task, as it's unable to use both the installer and the certificate for verification