### PR TITLE
Fix build-test-and-upload workflow

### DIFF
--- a/.github/workflows/build-test-and-upload.yaml
+++ b/.github/workflows/build-test-and-upload.yaml
@@ -29,7 +29,9 @@ jobs:
         uses: ./.github/actions/setup-build-environment
       - name: Build the collection
         uses: ./.github/actions/build-collection
-      - name: Run tests
-        uses: ./.github/actions/run-tests
+      - name: Run sanity tests
+        uses: ./.github/actions/run-sanity-tests
+      - name: Run component tests
+        uses: ./.github/actions/run-component-tests
       - name: Upload the collection
         uses: ./.github/actions/upload-collection


### PR DESCRIPTION
build-test-and-upload workflow was outdated and relied on non-existing actions