### PR TITLE
Remove update-version task from workflow

### DIFF
--- a/.github/workflows/build-test-and-publish.yaml
+++ b/.github/workflows/build-test-and-publish.yaml
@@ -27,8 +27,6 @@ jobs:
           fetch-depth: 0
       - name: Set environment variables
         uses: ./.github/actions/set-environment-variables
-      - name: Update version
-        uses: ./.github/actions/update-version
       - name: Set up environment
         uses: ./.github/actions/setup-build-environment
       - name: Build the collection


### PR DESCRIPTION
Updating version of galaxy.yml does not work as the master branch is protected.
Removing the step temporarly will allow us to make the release