### PR TITLE
Update readme regarding --preserve-installers switch

### DIFF
--- a/roles/oneagent/tests/README.md
+++ b/roles/oneagent/tests/README.md
@@ -26,6 +26,9 @@ local deployment are specified or any other platforms is used along with local o
 - venv 20.0+
 - 
 ## Running tests
+
+### Preparing test environment
+
 Upon downloading the collection
 
 ```commandline
@@ -43,11 +46,34 @@ $ pip install -r roles/oneagent/tests/requirements.txt
 $ mkdir -p roles/oneagent/files && wget https://ca.dynatrace.com/dt-root.cert.pem -P roles/oneagent/files
 $ ansible-galaxy collection build . -vvv
 $ sudo bash -c "source venv/bin/activate && ansible-galaxy collection install -vvv dynatrace-oneagent*"
+```
 
+### Running tests locally and remotely
+
+Running tests with regular manner requires one of the following commands:
+
+```commandline
 # Run tests for any platform (except from Windows) on local machine
 $ sudo bash -c "source venv/bin/activate && pytest roles/oneagent/tests --linux_x86=localhost"
 
 # Run tests with regular installer on remote Windows machine
 $ sudo bash -c "source venv/bin/activate && pytest roles/oneagent/tests --user=<USER> --password=<password> \
 --tenant=https://abc123456.com --tenant_token=<TOKEN> --windows_x86=<IP>"
+```
+
+There is also an option to run tests with placed-in installers using `--preserve-installers` switch. 
+In this mode, the test environment won't be fully cleaned. It requires that both installers differs in version and have 
+the naming schema from tenant, e.g. `Dynatrace-OneAgent-Linux-1.301.0.sh`, `Dynatrace-OneAgent-Linux-arm-1.302.0.sh`.
+Also, the installers certificate must be downloaded for successful run. </br>
+To run tests in this mode, download 2 versions of installers you want along with the certificate and place them in 
+`test_dir/installers` directory. Then, you can run the tests.
+
+```commandline
+# Create directory `test_dir/installers` and place the installers and certificate in it
+$ mkdir -p test_dir/installers
+$ cp /path/and/name/of/both/installers test_dir/installers
+$ wget https://ca.dynatrace.com/dt-root.cert.pem -P test_dir/installers
+
+# Run tests on local machine
+$ sudo bash -c "source venv/bin/activate && pytest roles/oneagent/tests --linux_x86=localhost --preserve_installers"
 ```

--- a/roles/oneagent/tests/README.md
+++ b/roles/oneagent/tests/README.md
@@ -65,6 +65,10 @@ There is also an option to run tests with placed-in installers using `--preserve
 In this mode, the test environment won't be fully cleaned. It requires that both installers differs in version and have 
 the naming schema from tenant, e.g. `Dynatrace-OneAgent-Linux-1.301.0.sh`, `Dynatrace-OneAgent-Linux-arm-1.302.0.sh`.
 Also, the installers certificate must be downloaded for successful run. </br>
+You can refer to [this documentation](https://docs.dynatrace.com/docs/shortlink/api-deployment-get-versions) on how to
+list available installers.
+For downloading the specific version of the OneAgent, visit
+[this documentation](https://docs.dynatrace.com/docs/shortlink/api-deployment-get-oneagent-version). </br>
 To run tests in this mode, download 2 versions of installers you want along with the certificate and place them in 
 `test_dir/installers` directory. Then, you can run the tests.
 

--- a/roles/oneagent/tests/README.md
+++ b/roles/oneagent/tests/README.md
@@ -31,7 +31,7 @@ local deployment are specified or any other platforms is used along with local o
 
 Upon downloading the collection
 
-```commandline
+```console
 # Install dependencies
 $ apt-get install -y python3-venv python3-pip sshpass
 
@@ -52,7 +52,7 @@ $ sudo bash -c "source venv/bin/activate && ansible-galaxy collection install -v
 
 Running tests with regular manner requires one of the following commands:
 
-```commandline
+```console
 # Run tests for any platform (except from Windows) on local machine
 $ sudo bash -c "source venv/bin/activate && pytest roles/oneagent/tests --linux_x86=localhost"
 
@@ -68,7 +68,7 @@ Also, the installers certificate must be downloaded for successful run. </br>
 To run tests in this mode, download 2 versions of installers you want along with the certificate and place them in 
 `test_dir/installers` directory. Then, you can run the tests.
 
-```commandline
+```console
 # Create directory `test_dir/installers` and place the installers and certificate in it
 $ mkdir -p test_dir/installers
 $ cp /path/and/name/of/both/installers test_dir/installers


### PR DESCRIPTION
--preserve-installers switch, which allows to run tests with placed-in installers was not documented