### PR TITLE
Changed default value of oneagent_force_cert_download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.3] - 2025-02-03
+- Fixed issue with skipping CA certificate transfer task
+
 ## [1.2.2] - 2025-10-1
 - Fixed linters issues
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: dynatrace
 name: oneagent
-version: 1.2.2
+version: 1.2.3
 readme: README.md
 authors:
   - Dynatrace LLC

--- a/roles/oneagent/tasks/provide-installer/signature-unix.yml
+++ b/roles/oneagent/tasks/provide-installer/signature-unix.yml
@@ -10,7 +10,7 @@
     src: "{{ oneagent_ca_cert_src_path }}"
     dest: "{{ oneagent_ca_cert_dest_path }}"
     mode: "0644"
-  when: not (oneagent_force_cert_download | default(true)) and _oneagent_ca_cert_state.stat.exists
+  when: not (oneagent_force_cert_download | default(false)) and _oneagent_ca_cert_state.stat.exists
 
 - name: Download CA certificate
   ansible.builtin.get_url:
@@ -20,7 +20,7 @@
     validate_certs: "{{ oneagent_validate_certs | default(true) }}"
   environment:
     SSL_CERT_FILE: "{{ oneagent_ca_cert_download_cert | default(omit) }}"
-  when: oneagent_force_cert_download | default(true) or not _oneagent_ca_cert_state.stat.exists
+  when: oneagent_force_cert_download | default(false) or not _oneagent_ca_cert_state.stat.exists
   changed_when: false
 
 - name: Validate installer signature

--- a/roles/oneagent/vars/main.yml
+++ b/roles/oneagent/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-oneagent_script_version: 1.2.2
+oneagent_script_version: 1.2.3
 oneagent_minimal_install_version: "1.199"
 oneagent_minimal_reporting_version: "1.203"
 


### PR DESCRIPTION
Changed default value of oneagent_force_cert_download for tasks: Transfer CA certificate and Download CA certificate to fix the issue with not transferring CA certificate.