### PR TITLE
Change tests installer server bind addr to 127.0.0.1

### DIFF
--- a/roles/oneagent/tests/conftest.py
+++ b/roles/oneagent/tests/conftest.py
@@ -2,7 +2,6 @@
 import logging
 import os
 import shutil
-import socket
 import time
 from collections.abc import Generator
 
@@ -127,7 +126,7 @@ def prepare_installers(request: FixtureRequest) -> None:
 @pytest.fixture(scope="session", autouse=True)
 def installer_server_url() -> Generator[str, None, None]:
     port = 8021
-    ipaddress = socket.gethostbyname(socket.gethostname())
+    ipaddress = "127.0.0.1"
     url = f"https://{ipaddress}:{port}"
 
     logging.info("Running installer server on %s", url)


### PR DESCRIPTION
It's a hotfix for the error in the Github actions pipeline:

```
>       self.socket.bind(self.server_address)
E       OSError: [Errno 99] Cannot assign requested address
```