### PR TITLE
Remove unintended config

### DIFF
--- a/roles/oneagent/README.md
+++ b/roles/oneagent/README.md
@@ -25,13 +25,7 @@ If you don't specify the installer, the script attempts to use the direct downlo
 
 ### Configure existing installation
 
-The role is capable of configuring existing installation by utilizing `oneagentctl`.
-There are 2 ways of applying configuration:
-
-- In case the Agent in the same or lower version is installed on specified host already, the script
-  uses provided installation parameters and runs `oneagentctl` with them, skipping installation procedure.
-- In case no `environment_url`, `paas_token` and `local_installer` parameters are provided,
-  the script runs `oneagentctl` with provided parameters directly.
+The role is capable of configuring existing installation by utilizing `oneagentctl`. In case no `environment_url`, `paas_token` and `local_installer` parameters are provided, the script runs `oneagentctl` with provided parameters directly.
 
 For full list of suitable parameters, see [OneAgent configuration via command-line interface].
 

--- a/roles/oneagent/tasks/gather-info/gather-info.yml
+++ b/roles/oneagent/tasks/gather-info/gather-info.yml
@@ -9,4 +9,3 @@
 - name: Determine deployment type
   ansible.builtin.set_fact:
     oneagent_is_operation_installation: "{{ _oneagent_is_installation_possible }}"
-    oneagent_is_operation_configuration: "{{ not _oneagent_is_installation_possible }}"


### PR DESCRIPTION
## Changes

The purpouse of the story was to remove unintended config feature, which was presented in the collection from very begining. 
The feature was able to alter the deployment process - if the same version was tried to be installed, the collection would try to apply the oneagentctl configuration, instead. The oneagent process would also be restarted for no reason.
Because of that, the feature was removed and now, the only way to configure the installation is to do it intentionally - following the README.md file