### PR TITLE
test: Add force flag to README

### DIFF
--- a/roles/oneagent/tests/README.md
+++ b/roles/oneagent/tests/README.md
@@ -52,8 +52,8 @@ $ pip install ansible
 
 # Build and install the collection
 $ mkdir -p roles/oneagent/files && wget https://ca.dynatrace.com/dt-root.cert.pem -P roles/oneagent/files
-$ ansible-galaxy collection build . -vvv
-$ sudo bash -c "source venv/bin/activate && ansible-galaxy collection install -vvv dynatrace-oneagent*"
+$ ansible-galaxy collection build . -vvvf
+$ sudo bash -c "source venv/bin/activate && ansible-galaxy collection install -vvvf dynatrace-oneagent*"
 ```
 
 ### Running tests locally and remotely


### PR DESCRIPTION
## Changes

`-f` flag was added to both ansible commands, used in preparing environment for local testing

## Please follow our general PR guidelines:

- [x] Make sure that changes are grouped in a sensible way 
- [x] Make sure that documentation is changed accordignly
- [x] Make sure that commits follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification 
