### PR TITLE
test: Remove preserve-installers option from tests

### DIFF
--- a/roles/oneagent/tests/README.md
+++ b/roles/oneagent/tests/README.md
@@ -68,24 +68,3 @@ $ sudo bash -c "source venv/bin/activate && pytest roles/oneagent/tests --linux_
 $ sudo bash -c "source venv/bin/activate && pytest roles/oneagent/tests --user=<USER> --password=<password> \
 --tenant=https://abc123456.com --tenant_token=<TOKEN> --windows_x86=<IP>"
 ```
-
-There is also an option to run tests with placed-in installers using `--preserve-installers` switch.
-In this mode, the test environment won't be fully cleaned. It requires that both installers differs in version and have
-the naming schema from tenant, e.g. `Dynatrace-OneAgent-Linux-1.301.0.sh`, `Dynatrace-OneAgent-Linux-arm-1.302.0.sh`.
-Also, the installers certificate must be downloaded for successful run. </br>
-You can refer to [this documentation](https://docs.dynatrace.com/docs/shortlink/api-deployment-get-versions) on how to
-list available installers.
-For downloading the specific version of the OneAgent, visit
-[this documentation](https://docs.dynatrace.com/docs/shortlink/api-deployment-get-oneagent-version). </br>
-To run tests in this mode, download 2 versions of installers you want along with the certificate and place them in
-`test_dir/installers` directory. Then, you can run the tests.
-
-```console
-# Create directory `test_dir/installers` and place the installers and certificate in it
-$ mkdir -p test_dir/installers
-$ cp /path/and/name/of/both/installers test_dir/installers
-$ wget https://ca.dynatrace.com/dt-root.cert.pem -P test_dir/installers
-
-# Run tests on local machine
-$ sudo bash -c "source venv/bin/activate && pytest roles/oneagent/tests --linux_x86=localhost --preserve_installers"
-```

--- a/roles/oneagent/tests/conftest.py
+++ b/roles/oneagent/tests/conftest.py
@@ -39,7 +39,6 @@ USER_KEY = "user"
 PASS_KEY = "password"
 TENANT_KEY = "tenant"
 TENANT_TOKEN_KEY = "tenant_token"
-PRESERVE_INSTALLERS_KEY = "preserve_installers"
 
 # Ini file configuration
 CA_CERT_URL_KEY = "dynatrace_ca_cert_url"
@@ -87,13 +86,6 @@ def wait_for_server_or_fail(url: str, max_attempts: int = 10) -> bool:
 @pytest.fixture(scope="session", autouse=True)
 def create_test_directories(request: FixtureRequest) -> None:
     logging.info("Creating working directories for tests")
-    if request.config.getoption(PRESERVE_INSTALLERS_KEY):
-        logging.info("Installers will be preserved, no installers will be generated")
-        shutil.rmtree(WORK_SERVER_DIR_PATH, ignore_errors=True)
-        shutil.rmtree(WORK_DIR_PATH, ignore_errors=True)
-    else:
-        shutil.rmtree(TEST_RUN_DIR_PATH, ignore_errors=True)
-
     os.makedirs(WORK_INSTALLERS_DIR_PATH, exist_ok=True)
     os.makedirs(WORK_SERVER_DIR_PATH, exist_ok=True)
     os.makedirs(WORK_DIR_PATH, exist_ok=True)
@@ -104,12 +96,7 @@ def prepare_installers(request: FixtureRequest) -> None:
     logging.info("Preparing installers...")
     tenant = request.config.getoption(TENANT_KEY)
     tenant_token = request.config.getoption(TENANT_TOKEN_KEY)
-    preserve_installers = request.config.getoption(PRESERVE_INSTALLERS_KEY)
     cert_url = str(request.config.getini(CA_CERT_URL_KEY))
-
-    if preserve_installers:
-        logging.info("Skipping installers preparation...")
-        return
 
     if is_local_deployment(request.config.platforms):
         logging.info("Generating installers...")
@@ -188,13 +175,6 @@ def pytest_addoption(parser: Parser) -> None:
         f"--{TENANT_TOKEN_KEY}",
         type=str,
         help="API key for downloading installer",
-        required=False,
-    )
-    parser.addoption(
-        f"--{PRESERVE_INSTALLERS_KEY}",
-        type=bool,
-        default=False,
-        help="Preserve installers after test run",
         required=False,
     )
 


### PR DESCRIPTION
This option is never used in CI environment and its implementation breaks tests logging functionality so it should be removed.

## Changes

<!-- Briefly describe why this PR is needed -->

## Please follow our general PR guidelines:

- [ ] Make sure that changes are grouped in a sensible way 
- [ ] Make sure that documentation is changed accordignly
- [ ] Make sure that commits follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification 
