### PR TITLE
chore: upgrade GitHub Actions to Node 24 (Node 20 deprecation)

### DIFF
--- a/.github/actions/run-component-tests/action.yaml
+++ b/.github/actions/run-component-tests/action.yaml
@@ -41,7 +41,7 @@ runs:
       run: sudo bash -c "source venv/bin/activate && pytest roles/oneagent/tests --linux_x86=localhost"
 
     - name: "Upload logs"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() }}
       with:
         name: component-tests-ansible-${{ inputs.ansible-version }}-${{ github.run_id }}

--- a/.github/actions/set-up-build-environment/action.yaml
+++ b/.github/actions/set-up-build-environment/action.yaml
@@ -23,7 +23,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.12"
     - name: "Upgrade pip"

--- a/.github/actions/upload-collection/action.yaml
+++ b/.github/actions/upload-collection/action.yaml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: "Publish artifact"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dynatrace-oneagent-${{ github.sha }}
         retention-days: 7

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -30,7 +30,7 @@ jobs:
         supported_ansible_versions: ${{ steps.v.outputs.supported_ansible_versions }}
         latest_ansible_version : ${{ steps.v.outputs.latest_ansible_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/get-ansible-versions
         id: v
 
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build with Ansible ${{ needs.fetch-ansible-versions.outputs.latest_ansible_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set environment variables
         uses: ./.github/actions/set-environment-variables
       - name: Set up environment
@@ -59,7 +59,7 @@ jobs:
       matrix:
           ansible-version: ${{ fromJson(needs.fetch-ansible-versions.outputs.supported_ansible_versions) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set environment variables
         uses: ./.github/actions/set-environment-variables
       - name: Set up environment

--- a/.github/workflows/check-commits.yaml
+++ b/.github/workflows/check-commits.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Checkout the branch
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
     if: ${{ inputs.github_publish }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Make GitHub release

--- a/.github/workflows/update-version-and-changelog.yaml
+++ b/.github/workflows/update-version-and-changelog.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Update version


### PR DESCRIPTION
## Summary

Upgrades outdated GitHub Actions to Node 24 compatible versions, fixing Node 20 deprecation warnings on GitHub-hosted runners.

**Related:** ASDY-27739

## Test plan

- [ ] CI passes on this PR
- [ ] No Node 20 deprecation warnings in workflow runs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)