### PR TITLE
move installation script to different root owned directory

### DIFF
--- a/roles/oneagent/README.md
+++ b/roles/oneagent/README.md
@@ -6,6 +6,7 @@
 - Script access to the OneAgent installer file. You can either:
   - configure the script to download the installer directly from your Dynatrace environment,
   - download it yourself and upload it to the primary node.
+- **Privilege escalation (`become: true`) is required on Linux and AIX.** The role installs OneAgent as root and creates a root-owned temporary directory to store the installer securely. Without privilege escalation the installation will fail. Enable it either at the play level (`become: true` in your playbook) or per host group in your inventory (`ansible_become: true`). On Windows, `become` is not supported and not needed.
 
 ### Direct download from your environment
 

--- a/roles/oneagent/tasks/cleanup/cleanup-unix.yml
+++ b/roles/oneagent/tasks/cleanup/cleanup-unix.yml
@@ -1,11 +1,7 @@
 ---
-- name: Remove leftover signature
+- name: Remove installer scratch directory
   ansible.builtin.file:
-    path: "{{ oneagent_ca_cert_dest_path }}"
+    path: "{{ _oneagent_installer_scratch.path }}"
     state: absent
-
-- name: Remove leftover installer
-  ansible.builtin.file:
-    path: "{{ oneagent_installer_path }}"
-    state: absent
+  when: _oneagent_installer_scratch.path is defined
   changed_when: false

--- a/roles/oneagent/tasks/params/params-unix.yml
+++ b/roles/oneagent/tasks/params/params-unix.yml
@@ -1,4 +1,16 @@
 ---
+- name: Determine effective user id
+  ansible.builtin.command: id -u
+  changed_when: false
+  check_mode: false
+  register: _oneagent_effective_uid
+
+- name: Validate that the role runs with root privileges
+  ansible.builtin.assert:
+    that: _oneagent_effective_uid.stdout == "0"
+    fail_msg: "{{ oneagent_root_privileges_required }}"
+    quiet: true
+
 - name: Validate installation directory name doesn't contains spaces
   ansible.builtin.fail:
     msg: "{{ oneagent_install_dir_contains_spaces }}"

--- a/roles/oneagent/tasks/provide-installer/download-unix.yml
+++ b/roles/oneagent/tasks/provide-installer/download-unix.yml
@@ -1,11 +1,4 @@
 ---
-- name: Ensure Download directory exists
-  ansible.builtin.file:
-    path: "{{ oneagent_download_path }}"
-    state: directory
-    mode: "0755"
-  when: not _oneagent_download_path_state.stat.exists
-
 - name: Check if OneAgent installer exists
   ansible.builtin.stat:
     path: "{{ oneagent_installer_path }}"

--- a/roles/oneagent/tasks/provide-installer/provide-installer.yml
+++ b/roles/oneagent/tasks/provide-installer/provide-installer.yml
@@ -1,4 +1,8 @@
 ---
+- name: Prepare private scratch directory for installer
+  ansible.builtin.include_tasks: provide-installer/scratch-dir-unix.yml
+  when: oneagent_system_is_unix
+
 - name: Check if installer should be downloaded
   ansible.builtin.set_fact:
     _oneagent_skip_installer_download: >-

--- a/roles/oneagent/tasks/provide-installer/scratch-dir-unix.yml
+++ b/roles/oneagent/tasks/provide-installer/scratch-dir-unix.yml
@@ -1,0 +1,29 @@
+---
+- name: Ensure download directory exists
+  ansible.builtin.file:
+    path: "{{ oneagent_download_path }}"
+    state: directory
+    mode: "0755"
+  when: not ansible_check_mode and not _oneagent_download_path_state.stat.exists
+
+- name: Create private scratch directory for installer
+  ansible.builtin.tempfile:
+    state: directory
+    path: "{{ oneagent_download_path }}"
+    prefix: "dynatrace-oneagent-"
+  register: _oneagent_installer_scratch
+  when: not ansible_check_mode
+
+- name: Lock scratch directory to root only
+  ansible.builtin.file:
+    path: "{{ _oneagent_installer_scratch.path }}"
+    state: directory
+    mode: "0700"
+    owner: root
+  when: not ansible_check_mode
+
+- name: Redirect installer and CA cert into scratch directory
+  ansible.builtin.set_fact:
+    oneagent_installer_path: "{{ _oneagent_installer_scratch.path }}/{{ oneagent_installer_path | basename }}"
+    oneagent_ca_cert_dest_path: "{{ _oneagent_installer_scratch.path }}/{{ oneagent_ca_cert_dest_path | basename }}"
+  when: not ansible_check_mode

--- a/roles/oneagent/tests/conftest.py
+++ b/roles/oneagent/tests/conftest.py
@@ -12,6 +12,7 @@ from ansible.config import AnsibleConfigurator
 from ansible.runner import AnsibleRunner
 from command.platform_command_wrapper import PlatformCommandWrapper
 from constants import (
+    UNIX_DOWNLOAD_DIR_PATH,
     WORK_DIR_PATH,
     WORK_INSTALLERS_DIR_PATH,
     WORK_SERVER_DIR_PATH,
@@ -157,6 +158,9 @@ def handle_test_environment(
     perform_operation_on_platforms(platforms, check_agent_state, wrapper, False)
 
     shutil.rmtree("/var/lib/dynatrace", ignore_errors=True)
+
+    for leftover in UNIX_DOWNLOAD_DIR_PATH.glob("dynatrace-oneagent-*"):
+        shutil.rmtree(leftover, ignore_errors=True)
 
 
 def pytest_addoption(parser: Parser) -> None:

--- a/roles/oneagent/tests/deployment/deployment_operations.py
+++ b/roles/oneagent/tests/deployment/deployment_operations.py
@@ -165,6 +165,7 @@ def check_download_directory(
 ) -> None:
     logging.debug("Platform: %s, IP: %s", platform, address)
     download_path: Path = select_by_platform(platform, unix_path, windows_path)
-    installer_path = download_path / f"{INSTALLER_PARTIAL_NAME}*"
+    installer_glob = select_by_platform(platform, f"*/{INSTALLER_PARTIAL_NAME}*", f"{INSTALLER_PARTIAL_NAME}*")
+    installer_path = download_path / installer_glob
     assert wrapper.directory_exists(platform, address, download_path).returncode == 0
     assert wrapper.file_exists(platform, address, installer_path).returncode == (0 if exists else 1)

--- a/roles/oneagent/tests/test_install_and_config.py
+++ b/roles/oneagent/tests/test_install_and_config.py
@@ -77,6 +77,39 @@ def _check_output_for_secrets(result: DeploymentResult, installer_server_url: st
         assert installer_server_url not in out.stderr
 
 
+def test_missing_download_directory(
+    runner: AnsibleRunner,
+    configurator: AnsibleConfigurator,
+    platforms: PlatformCollection,
+    wrapper: PlatformCommandWrapper,
+    installer_server_url: str,
+):
+    set_installer_download_params(configurator, installer_server_url)
+    configurator.set_common_parameter(configurator.VALIDATE_DOWNLOAD_CERTS_KEY, False)
+
+    unix_download_dir = UNIX_DOWNLOAD_DIR_PATH / "oneagent-missing-download-dir"
+    windows_download_dir = WINDOWS_DOWNLOAD_DIR_PATH / "oneagent-missing-download-dir"
+
+    for platform in platforms:
+        download_dir: Path = select_by_platform(platform, unix_download_dir, windows_download_dir)
+        configurator.set_platform_parameter(platform, configurator.DOWNLOAD_DIR_KEY, str(download_dir))
+
+    run_deployment(runner, configurator)
+
+    logging.info("Check if agent is installed")
+    perform_operation_on_platforms(platforms, check_agent_state, wrapper, True)
+
+    logging.info("Check if the missing download directory was created and the installer cleaned up")
+    perform_operation_on_platforms(
+        platforms,
+        check_download_directory,
+        wrapper,
+        False,
+        unix_download_dir,
+        windows_download_dir,
+    )
+
+
 def test_basic_installation(
     runner: AnsibleRunner,
     configurator: AnsibleConfigurator,

--- a/roles/oneagent/vars/messages.yml
+++ b/roles/oneagent/vars/messages.yml
@@ -15,3 +15,7 @@ oneagent_signature_verification_failed: "Signature verification failed: %s"
 oneagent_uninstall_failed_unix: "Uninstall failed, exit code: %d, output: %s %s"
 oneagent_reboot_failed: Failed to reboot the host
 oneagent_fetch_metadata_failed: "Failed to fetch metadata from tenant: %s"
+oneagent_root_privileges_required: >-
+  This role requires root privileges on Linux and AIX. Enable privilege escalation
+  via 'become: true' at the play level or 'ansible_become: true' in your inventory.
+  Please see the role README for further information.


### PR DESCRIPTION
Place the installer in a root-owned 0700 subdirectory inside the download path.

Previously installer was placed in /tmp/Dynatrace-OneAgent-Linux-latest.sh now it stays inside/tmp/dynatrace-oneagent-XXXXXX/Dynatrace-OneAgent-Linux-latest.sh instead.

Updated README with `become: true` the role never actually worked correctly without it, so this isn't a regression, it just now fails earlier and more visibly.