### PR TITLE
ci(scorecard): add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,43 @@
+name: OpenSSF Scorecard
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Scorecard results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: openssf-scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload results to code scanning
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
adding OpenSSF Scorecard

## Changes

<!-- Briefly describe why this PR is needed -->
https://github.com/dynatrace-oss/Open-Source-Hub/blob/main/inventory/dynatrace/ossf-scorecard.md (edited) 
[12:46 PM]The OSPO identified the repo as a potential strategic repo. We are adding the the [OpenSSF Scorecard](https://scorecard.dev/) to those projects.
 
## Please follow our general PR guidelines:

- [ ] Make sure that changes are grouped in a sensible way 
- [ ] Make sure that documentation is changed accordignly
- [ ] Make sure that commits follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification 
